### PR TITLE
Fix compilation with OCaml 4.02

### DIFF
--- a/cppo_ocamlbuild.opam
+++ b/cppo_ocamlbuild.opam
@@ -9,6 +9,7 @@ depends: [
   "ocaml"
   "dune" {build & >= "1.0"}
   "ocamlbuild"
+  "ocamlfind"
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
This commit returns this fix from opam-repository: https://github.com/ocaml/opam-repository/pull/14207
The issue is that the `ocamlbuild` META file is not present by default in OCaml 4.02 and is only installed by ocamlfind. Relying always on ocamlfind is not detrimental in most cases because you need ocamlfind in order to use `cppo_ocamlfind` anyway.