### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/cppo.opam
+++ b/cppo.opam
@@ -7,7 +7,7 @@ doc: "https://ocaml-community.github.io/cppo/"
 bug-reports: "https://github.com/ocaml-community/cppo/issues"
 depends: [
   "ocaml" {>= "4.03"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "base-unix"
 ]
 build: [

--- a/cppo_ocamlbuild.opam
+++ b/cppo_ocamlbuild.opam
@@ -7,7 +7,7 @@ doc: "https://ocaml-community.github.io/cppo/"
 bug-reports: "https://github.com/ocaml-community/cppo/issues"
 depends: [
   "ocaml"
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "ocamlbuild"
   "ocamlfind"
 ]


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.