### PR TITLE
Update the installation command in the readme

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,11 +13,5 @@ make
 Install:
 
 ```
-make PREFIX=/some/path install
-```
-
-or
-
-```
-make BINDIR=/some/path/bin install
+make DESTDIR=/some/path install
 ```


### PR DESCRIPTION
Because `dune` is used for the installation. `dune install` relies on the `DESTDIR` environment variable, not the `PREFIX` or `BINDIR` ones.