### PR TITLE
Recognise OCaml 4.12 pre-release versions

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+## v1.6.7 (2020-??-??)
+- [compat] Treat ~ and - the same in semver in order to parse
+           OCaml 4.12.0 pre-release versions.
+
 ## v1.6.6 (2019-05-27)
 - [pkg] port build system to dune from jbuilder.
 - [pkg] upgrade opam metadata to 2.0 format.

--- a/src/cppo_main.ml
+++ b/src/cppo_main.ml
@@ -18,7 +18,7 @@ let semver_re = Str.regexp "\
 \\([0-9]+\\)\
 \\.\\([0-9]+\\)\
 \\.\\([0-9]+\\)\
-\\(-\\([^+]*\\)\\)?\
+\\([~-]\\([^+]*\\)\\)?\
 \\(\\+\\(.*\\)\\)?\
 \r?$"
 
@@ -108,6 +108,10 @@ let main () =
             VAR_VERSION_FULL    is the original string
 
           Example: cppo -V OCAML:4.02.1
+
+          Note that cppo recognises both '-' and '~' preceding the pre-release
+          meaning -V OCAML:4.11.0+alpha1 sets OCAML_BUILD to alpha1 but
+          -V OCAML:4.12.0~alpha1 sets OCAML_PRERELEASE to alpha1.
 ";
 
     "-o", Arg.String (fun s -> out_file := Some s),


### PR DESCRIPTION
OCaml 4.11 introduced a new separator the for the additional-info portion and the 4.12 pre-releases have started using this. `Sys.ocaml_version` for 4.12.0 alpha1 is therefore `4.12.0~alpha1` (using Debian versioning conventions). This doesn't parse with cppo.

A solution - here - is to treat `-` and `~` as the same. This is an easy fix, although it means that the pre-release information now gets put in the `_PRERELEASE` variable rather than `_BUILD` as it was before. To me, this is more appropriate, (OCaml's version number doesn't include it, but it means that variants such as `4.12.0~alpha1+flambda` would put `_PRELEASE` as `alpha1` and `_BUILD` as `flambda` (which I think is better).

An alternative would be to treat `+` and `~` as equivalent which would then put the whole thing in `_BUILD` as before.