### PR TITLE
Restore 4.02 compatibility

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 ## v1.6.7 (2020-??-??)
 - [compat] Treat ~ and - the same in semver in order to parse
            OCaml 4.12.0 pre-release versions.
+- [compat] Restore 4.02.3 compatibility.
 
 ## v1.6.6 (2019-05-27)
 - [pkg] port build system to dune from jbuilder.

--- a/cppo.opam
+++ b/cppo.opam
@@ -6,7 +6,7 @@ homepage: "http://mjambon.com/cppo.html"
 doc: "https://ocaml-community.github.io/cppo/"
 bug-reports: "https://github.com/ocaml-community/cppo/issues"
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.02.3"}
   "dune" {>= "1.0"}
   "base-unix"
 ]

--- a/src/compat.ml
+++ b/src/compat.ml
@@ -1,0 +1,7 @@
+if Filename.check_suffix Sys.argv.(1) ".ml" &&
+   Scanf.sscanf Sys.ocaml_version "%d.%d" (fun a b -> (a, b)) < (4, 03) then
+  print_endline "\
+module String = struct
+  include String
+  let capitalize_ascii = capitalize
+end"

--- a/src/dune
+++ b/src/dune
@@ -13,4 +13,9 @@
  (name cppo_main)
  (package cppo)
  (public_name cppo)
+ (modules :standard \ compat)
+ (preprocess (per_module
+  ((action (progn
+    (run ocaml %{dep:compat.ml} %{input-file})
+    (cat %{input-file}))) cppo_eval)))
  (libraries unix str))


### PR DESCRIPTION
Compatibility at the other end of the spectrum this time! 97617417d5093d73e0680c4c52f38d07b04c4300 got rid of a single deprecation warning. This PR uses `preprocess` to provide `String.capitalize_ascii` on 4.02.3.

I hit a catch-22 of wanting cppo 1.6.6 on opam's 2.0 branch in order to have `dune` files but also needing 4.02.3 support for our LTS branch... the patch sits in opam's vendoring system, so just offering here if of interest.