### PR TITLE
Allow empty patch version

### DIFF
--- a/src/cppo_main.ml
+++ b/src/cppo_main.ml
@@ -17,7 +17,7 @@ let add_extension tbl s =
 let semver_re = Str.regexp "\
 \\([0-9]+\\)\
 \\.\\([0-9]+\\)\
-\\.\\([0-9]+\\)\
+\\(\\.\\([0-9]+\\)\\)?\
 \\([~-]\\([^+]*\\)\\)?\
 \\(\\+\\(.*\\)\\)?\
 \r?$"
@@ -28,9 +28,9 @@ let parse_semver s =
   else
     let major = Str.matched_group 1 s in
     let minor = Str.matched_group 2 s in
-    let patch = Str.matched_group 3 s in
-    let prerelease = try Some (Str.matched_group 5 s) with Not_found -> None in
-    let build = try Some (Str.matched_group 7 s) with Not_found -> None in
+    let patch = try (Str.matched_group 4 s) with Not_found -> "0" in
+    let prerelease = try Some (Str.matched_group 6 s) with Not_found -> None in
+    let build = try Some (Str.matched_group 8 s) with Not_found -> None in
     Some (major, minor, patch, prerelease, build)
 
 let define var s =

--- a/test/dune
+++ b/test/dune
@@ -70,7 +70,7 @@
  (action
   (with-stdout-to
    %{targets}
-   (run %{bin:cppo} -V X:123.05.2-alpha.1+foo-2.1 %{<}))))
+   (run %{bin:cppo} -V X:123.05.2-alpha.1+foo-2.1 -V COQ:8.13+beta1 %{<}))))
 
 (alias
  (name runtest)

--- a/test/version.cppo
+++ b/test/version.cppo
@@ -28,3 +28,5 @@ patch: X_PATCH
 #else
   #error ""
 #endif
+
+Coq: COQ_VERSION


### PR DESCRIPTION
Doesn't fix compatibility with Coq `8.13.dev` (which should be later than `8.13.2`), but can at least deal with `8.13+beta1`.