### PR TITLE
Higher-order macros and macro definitions with explicit delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ BLANK* "#" BLANK* ("define"|"undef"
 
 Directives can be split into multiple lines by placing a backslash `\` at
 the end of the line to be continued. In general, any special character
-can used as a normal character by preceding it with backslash.
+can be used as a normal character by preceding it with backslash.
 
 
 File inclusion

--- a/README.md
+++ b/README.md
@@ -113,9 +113,13 @@ An important distinction with cpp is that only previously-defined
 macros are accessible. Defining, undefining or redefining a macro has
 no effect on how previous macros will expand.
 
-Macros can take arguments ("function-like macro" in the cpp
-jargon). Both in the definition (`#define`) and in macro application the
-opening parenthesis must stick to the macro's identifier:
+Macros can take arguments. That is, a macro can be parameterized;
+this is known as a "function-like macro" in `cpp` jargon.
+When a parameterized macro is defined
+and when it is applied,
+the opening parenthesis must stick to the macro's identifier:
+that is, there must be no space in between.
+For example, this text:
 
 ```ocaml
 #define debug(args) if !debugging then Printf.eprintf args else ()
@@ -129,7 +133,25 @@ is expanded into:
 if !debugging then Printf.eprintf "Testing %i" (1 + 1) else ()
 ```
 
-Here is a multiline macro definition. Newlines occurring between
+An ordinary macro, which takes no arguments, can be viewed as
+a parameterized macro that takes zero arguments. However, the
+syntax differs: when there is no argument, no parentheses are
+used; when there is at least one argument, parentheses must be used.
+Here is a summary of the valid syntaxes:
+
+```ocaml
+#define FOO 42      (* Definition of an ordinary macro *)
+FOO                 (* A use of an ordinary macro *)
+
+#define BAR() 42    (* Invalid! When parentheses are used,
+                       there must be at least one parameter *)
+
+#define BAR(x) 42+x (* Definition of a parameterized macro *)
+BAR(0)              (* A use of this parameterized macro *)
+BAR()               (* Another valid use -- the argument is empty *)
+```
+
+Here is a multi-line macro definition. Newlines occurring between
 tokens must be protected by a backslash:
 
 ```ocaml

--- a/README.md
+++ b/README.md
@@ -180,6 +180,72 @@ cppo -D 'VERSION 1.0' example.ml
 ocamlopt -c -pp "cppo -D 'VERSION 1.0'" example.ml
 ```
 
+Higher-Order Macros
+-------------------
+A parameterized macro can take a parameterized macro as a parameter:
+this is known as a higher-order macro.
+
+To enable this feature, some annotations are required:
+when a macro parameter is itself a parameterized macro,
+it must be annotated with its type.
+
+A macro takes *n* arguments (where *n* can be zero)
+and returns a piece of text.
+So, to describe the type of a macro, it suffices to
+describe the types of its *n* arguments.
+
+Thus, the syntax of types is
+`τ ::= [τ ... τ]`.
+That is, a type is a sequence of *n* types,
+  without separators,
+surrounded with square brackets.
+An ordinary macro,
+which takes zero parameters,
+has type `[]`.
+This is the base type: in other words, it is the type of text.
+For greater readability,
+this type can also be written in the form of a single period, `.`.
+Here are a few examples of types:
+
+```ocaml
+  .       (* An ordinary unparameterized macro: in other words, text    *)
+  []      (* Same as above.                                             *)
+  [.]     (* A parameterized macro that expects one piece of text       *)
+  [..]    (* A parameterized macro that expects two pieces of text      *)
+  [[.].]  (* A parameterized macro
+             whose first parameter is a parameterized macro of type [.]
+             and whose second parameter is a piece of text              *)
+```
+
+In the definition of a parameterized macro `M`,
+each parameter `X` can be annotated with a type
+by writing `X : τ`.
+This is optional: if no annotation is provided,
+the base type `.` is assumed.
+If a parameter `X` is annotated with a type `τ` other than the base type,
+then, when the parameterized macro `M` is applied,
+the actual argument `Y` that is supplied as an instance for `X`
+must be the name of a macro of type `τ`.
+
+This is more easily explained via an example. In the following code,
+
+```ocaml
+#define TWICE(e)          (e + e)
+#define APPLY(F : [.], e) (let x = (e) in F(x))
+let forty_two =
+  APPLY(TWICE,1+2+3+4+5+6)
+```
+
+`TWICE` is a parameterized macro of type `[.]`, and
+`APPLY` is a higher-order macro, whose type is `[[.].]`.
+Thus, the application `APPLY(TWICE, ...)` is valid.
+This code is expanded into:
+
+```
+let forty_two =
+   (let x = (1+2+3+4+5+6) in (x + x))
+```
+
 Conditionals
 ------------
 

--- a/src/cppo_eval.ml
+++ b/src/cppo_eval.ml
@@ -389,11 +389,11 @@ let parse ~preserve_quotations file lexbuf =
     Cppo_parser.main (Cppo_lexer.line lexer_env) lexbuf
   with
       Parsing.Parse_error ->
-        error (Cppo_lexer.loc lexbuf) "syntax error"
+        error (Cppo_lexer.long_loc lexer_env) "syntax error"
     | Cppo_types.Cppo_error _ as e ->
         raise e
     | e ->
-        error (Cppo_lexer.loc lexbuf) (Printexc.to_string e)
+        error (Cppo_lexer.long_loc lexer_env) (Printexc.to_string e)
 
 let plural n =
   if abs n <= 1 then ""

--- a/src/cppo_eval.ml
+++ b/src/cppo_eval.ml
@@ -25,11 +25,14 @@ type entry =
 and env =
   entry M.t
 
+let basic x : formal =
+  (x, base)
+
 let ident x =
   `Ident (dummy_loc, x, [])
 
 let dummy_defun formals body env =
-  EDef (dummy_loc, formals, body, env)
+  EDef (dummy_loc, List.map basic formals, body, env)
 
 let builtins : (string * (env -> entry)) list = [
   "STRINGIFY",
@@ -448,8 +451,8 @@ let check_arity loc name (formals : _ list) (actuals : _ list) =
 (* [bind_one formal (loc, actual, env) accu] binds one formal parameter
    to one actual argument, extending the environment [accu]. This formal
    parameter becomes an ordinary (unparameterized) macro. *)
-let bind_one formal (loc, actual, env) accu =
-  M.add formal (EDef (loc, [], actual, env)) accu
+let bind_one ((x, _shape) : formal) (loc, actual, env) accu =
+  M.add x (EDef (loc, [], actual, env)) accu
 
 (* [bind_many formals (loc, actuals, env) accu] binds a tuple of formal
    parameters to a tuple of actual arguments, extending the environment

--- a/src/cppo_eval.ml
+++ b/src/cppo_eval.ml
@@ -609,7 +609,7 @@ and expand_node ?(top = false) g env0 (x : node) =
         Buffer.add_string g.buf s;
         env0
 
-    | `Seq l ->
+    | `Seq (_loc, l) ->
         expand_list g env0 l
 
     | `Stringify x ->

--- a/src/cppo_lexer.mll
+++ b/src/cppo_lexer.mll
@@ -453,8 +453,12 @@ and ocaml_token e = parse
       { e.line_start <- false;
         TEXT (loc lexbuf, false, lexeme lexbuf) }
 
+  (* At the end of the file, the lexer normally produces EOF. However,
+     if we are currently inside a definition (opened by #define) then
+     the lexer produces ENDEF followed by EOF. *)
   | eof
-      { EOF }
+      { if e.in_directive then (e.in_directive <- false; ENDEF (loc lexbuf))
+        else EOF }
 
 
 and comment startloc e depth = parse

--- a/src/cppo_lexer.mll
+++ b/src/cppo_lexer.mll
@@ -181,18 +181,16 @@ and line e = parse
           match e.lexer with
               `Test -> lexer_error lexbuf "Syntax error in boolean expression"
             | `Ocaml ->
+                clear e;
                 if e.line_start then (
                   e.in_directive <- true;
-                  clear e;
                   add e s;
                   e.token_start <- pos1 lexbuf;
                   e.line_start <- false;
                   directive e lexbuf
                 )
-                else (
-                  clear e;
+                else
                   TEXT (loc lexbuf, false, s)
-                )
         }
 
   | ""  { clear e;

--- a/src/cppo_lexer.mll
+++ b/src/cppo_lexer.mll
@@ -163,19 +163,7 @@ let line = ( [^'\n'] | '\\' ('\r'? '\n') )* ('\n' | eof)
 let dblank0 = (blank | '\\' '\r'? '\n')*
 let dblank1 = blank (blank | '\\' '\r'? '\n')*
 
-rule token e = parse
-    ""
-      {
-        (*
-          We use two different lexers for boolean expressions in #if directives
-          and for regular OCaml tokens.
-        *)
-        match e.lexer with
-            `Ocaml -> ocaml_token e lexbuf
-          | `Test -> test_token e lexbuf
-      }
-
-and line e = parse
+rule line e = parse
     blank* "#" as s
         {
           match e.lexer with
@@ -194,7 +182,12 @@ and line e = parse
         }
 
   | ""  { clear e;
-          token e lexbuf }
+          (* We use two different lexers: [ocaml_token] is used for ordinary
+             OCaml tokens; [test_token] is used inside the Boolean expression
+             that follows an #if directive. *)
+          match e.lexer with
+          | `Ocaml -> ocaml_token e lexbuf
+          | `Test -> test_token e lexbuf }
 
 and directive e = parse
 

--- a/src/cppo_lexer.mll
+++ b/src/cppo_lexer.mll
@@ -190,7 +190,6 @@ and line e = parse
                   directive e lexbuf
                 )
                 else (
-                  e.line_start <- false;
                   clear e;
                   TEXT (loc lexbuf, false, s)
                 )

--- a/src/cppo_lexer.mll
+++ b/src/cppo_lexer.mll
@@ -212,8 +212,7 @@ and directive e = parse
   (* If #define <name> is not followed with an opening parenthesis then this
      is interpreted as an ordinary (non-parameterized) macro definition. *)
   | blank* "define" dblank1 (ident as id)
-      { assert e.in_directive;
-        let xs = [] in
+      { let xs = [] in
         DEF (long_loc e, id, xs) }
 
   | blank* "undef" dblank1 (ident as id)

--- a/src/cppo_lexer.mll
+++ b/src/cppo_lexer.mll
@@ -716,10 +716,10 @@ and formals xs = parse
   | (ident as x) blank* ","
       { formals (x :: xs) lexbuf }
   | ")"
-      { lexer_error lexbuf "At least one argument is required" }
+      { lexer_error lexbuf "A macro must have at least one formal parameter" }
   | _
   | eof
-      { lexer_error lexbuf "Invalid argument list" }
+      { lexer_error lexbuf "Invalid formal parameter: expected an identifier" }
 
 {
   let init ~preserve_quotations file lexbuf =

--- a/src/cppo_lexer.mll
+++ b/src/cppo_lexer.mll
@@ -185,10 +185,12 @@ rule line e = parse
     {
       assert_ocaml_lexer e lexbuf;
       clear e;
+      (* We systematically set [e.token_start], so that [long_loc e] will
+         correctly produce the location of the last token. *)
+      e.token_start <- pos1 lexbuf;
       if e.line_start then (
         e.in_directive <- true;
         add e s;
-        e.token_start <- pos1 lexbuf;
         e.line_start <- false;
         directive e lexbuf
       )
@@ -198,6 +200,9 @@ rule line e = parse
 
   | ""
       { clear e;
+        (* We systematically set [e.token_start], so that [long_loc e] will
+           correctly produce the location of the last token. *)
+        e.token_start <- pos1 lexbuf;
         match e.lexer with
         | `Ocaml -> ocaml_token e lexbuf
         | `Test -> test_token e lexbuf }

--- a/src/cppo_lexer.mll
+++ b/src/cppo_lexer.mll
@@ -122,6 +122,13 @@ let is_reserved_directive =
   List.iter (fun s -> Hashtbl.add tbl s ()) cppo_directives;
   fun s -> Hashtbl.mem tbl s
 
+let assert_ocaml_lexer e lexbuf =
+  match e.lexer with
+  | `Test ->
+      lexer_error lexbuf "Syntax error in boolean expression"
+  | `Ocaml ->
+      ()
+
 }
 
 (* standard character classes used for macro identifiers *)
@@ -174,20 +181,17 @@ rule line e = parse
      of a line. *)
   | blank* "#" as s
     {
-      match e.lexer with
-      | `Test ->
-          lexer_error lexbuf "Syntax error in boolean expression"
-      | `Ocaml ->
-          clear e;
-          if e.line_start then (
-            e.in_directive <- true;
-            add e s;
-            e.token_start <- pos1 lexbuf;
-            e.line_start <- false;
-            directive e lexbuf
-          )
-          else
-            TEXT (loc lexbuf, false, s)
+      assert_ocaml_lexer e lexbuf;
+      clear e;
+      if e.line_start then (
+        e.in_directive <- true;
+        add e s;
+        e.token_start <- pos1 lexbuf;
+        e.line_start <- false;
+        directive e lexbuf
+      )
+      else
+        TEXT (loc lexbuf, false, s)
     }
 
   | ""

--- a/src/cppo_parser.mly
+++ b/src/cppo_parser.mly
@@ -54,6 +54,13 @@ pnode_list0:
 |                    { [] }
 ;
 
+actual:
+| pnode_list0        { let pos1 = Parsing.symbol_start_pos()
+                       and pos2 = Parsing.symbol_end_pos() in
+                       let loc = (pos1, pos2) in
+                       `Seq (loc, $1) }
+;
+
 /* node in which opening and closing parentheses don't need to match */
 unode:
 | node          { $1 }
@@ -85,7 +92,7 @@ node:
 | IDENT         { let loc, name = $1 in
                   `Ident (loc, name, []) }
 
-| FUNIDENT args1 CL_PAREN
+| FUNIDENT actuals1 CL_PAREN
                 {
                 (* macro application that receives at least one argument,
                    possibly empty.  We cannot distinguish syntactically between
@@ -180,9 +187,9 @@ elif_list:
 |                  { [] }
 ;
 
-args1:
-  pnode_list0 COMMA args1   { $1 :: $3  }
-| pnode_list0               { [ $1 ] }
+actuals1:
+  actual COMMA actuals1 { $1 :: $3  }
+| actual                { [ $1 ] }
 ;
 
 pnode_or_comma_list0:

--- a/src/cppo_parser.mly
+++ b/src/cppo_parser.mly
@@ -4,7 +4,7 @@
 
 /* Directives */
 %token < Cppo_types.loc * string > UNDEF INCLUDE WARNING ERROR
-%token < Cppo_types.loc * string * string list > DEF
+%token < Cppo_types.loc * string * (string * Cppo_types.shape) list > DEF
 %token < Cppo_types.loc * string option * int > LINE
 %token < Cppo_types.loc * Cppo_types.bool_expr > IFDEF
 %token < Cppo_types.loc * string * string > EXT

--- a/src/cppo_parser.mly
+++ b/src/cppo_parser.mly
@@ -132,8 +132,8 @@ node:
 | DEF body EOF
                 { let loc, _name, _formals = $1 in
                   error loc "This #def is never closed: perhaps #enddef is missing" }
-                (* We include this rule in order to produce a good error message
-                   when a #def has no matching #enddef. *)
+                /* We include this rule in order to produce a good error message
+                   when a #def has no matching #enddef. */
 
 | UNDEF
                 { `Undef $1 }

--- a/src/cppo_parser.mly
+++ b/src/cppo_parser.mly
@@ -71,7 +71,10 @@ pnode:
                     `Text ($3, false, ")") ::
                     []
                   in
-                  `Seq nodes }
+                  let pos1, _ = $1
+                  and _, pos2 = $3 in
+                  let loc = (pos1, pos2) in
+                  `Seq (loc, nodes) }
 ;
 
 /* node without parentheses handling (need to use unode or pnode) */

--- a/src/cppo_parser.mly
+++ b/src/cppo_parser.mly
@@ -65,9 +65,13 @@ unode:
 pnode:
 | node          { $1 }
 | OP_PAREN pnode_or_comma_list0 CL_PAREN
-                { `Seq [`Text ($1, false, "(");
-                        `Seq $2;
-                        `Text ($3, false, ")")] }
+                { let nodes =
+                    `Text ($1, false, "(") ::
+                    $2 @
+                    `Text ($3, false, ")") ::
+                    []
+                  in
+                  `Seq nodes }
 ;
 
 /* node without parentheses handling (need to use unode or pnode) */

--- a/src/cppo_parser.mly
+++ b/src/cppo_parser.mly
@@ -129,6 +129,12 @@ node:
                   let _, pos2 = $3 in
                   `Def ((pos1, pos2), name, formals, body) }
 
+| DEF body EOF
+                { let loc, _name, _formals = $1 in
+                  error loc "This #def is never closed: perhaps #enddef is missing" }
+                (* We include this rule in order to produce a good error message
+                   when a #def has no matching #enddef. *)
+
 | UNDEF
                 { `Undef $1 }
 | WARNING

--- a/src/cppo_types.ml
+++ b/src/cppo_types.ml
@@ -63,7 +63,7 @@ type node =
     | `Error of (loc * string)
     | `Warning of (loc * string)
     | `Text of (loc * bool * string) (* bool is true for space tokens *)
-    | `Seq of node list
+    | `Seq of (loc * node list)
     | `Stringify of node
     | `Capitalize of node
     | `Concat of (node * node)
@@ -120,5 +120,5 @@ let rec flatten_nodes (l: node list): node list =
 
 and flatten_node (node: node): node list =
   match node with
-  | `Seq l -> flatten_nodes l
+  | `Seq (_loc, l) -> flatten_nodes l
   | x -> [x]

--- a/src/cppo_types.ml
+++ b/src/cppo_types.ml
@@ -19,6 +19,22 @@ type macro =
 type shape =
   | Shape of shape list
 
+(* Printing a shape. This code must be consistent with the shape
+   parser in [Cppo_lexer]. *)
+
+let rec print_shape (Shape shs) =
+  match shs with
+  | [] ->
+      (* As a special case, the base shape is ".". *)
+      "."
+  | _ ->
+      "[" ^ String.concat "" (List.map print_shape shs) ^ "]"
+
+(* Testing two shapes for equality. *)
+
+let same_shape : shape -> shape -> bool =
+  (=)
+
 (* The base shape. This is the shape of a basic macro,
    which takes no parameters, and produces text. *)
 let base = Shape []

--- a/src/cppo_types.ml
+++ b/src/cppo_types.ml
@@ -10,6 +10,19 @@ type loc = position * position
 type macro =
   string
 
+(* The shape of a macro.
+
+   The abstract syntax of shapes is τ ::= [τ, ..., τ].
+   That is, a macro takes a tuple of parameters, each
+   of which has a shape. The length of of this tuple
+   can be zero: this is the base case. *)
+type shape =
+  | Shape of shape list
+
+(* The base shape. This is the shape of a basic macro,
+   which takes no parameters, and produces text. *)
+let base = Shape []
+
 type bool_expr =
     [ `True
     | `False
@@ -71,9 +84,11 @@ type node =
     | `Current_line of loc
     | `Current_file of loc ]
 
-(* One formal macro parameter. *)
+(* A formal macro parameter consists of an identifier (the name of this
+   parameter) and a shape (the shape of this parameter). In the concrete
+   syntax, if the shape is omitted, then the base shape is assumed. *)
 and formal =
-  string
+  string * shape
 
 (* A tuple of formal macro parameters. *)
 and formals =

--- a/src/cppo_types.ml
+++ b/src/cppo_types.ml
@@ -112,7 +112,7 @@ and formals =
 
 (* One actual macro argument. *)
 and actual =
-  node list
+  node
 
 (* A tuple of actual macro arguments. *)
 and actuals =

--- a/src/cppo_types.ml
+++ b/src/cppo_types.ml
@@ -146,14 +146,6 @@ let warning loc s =
 
 let dummy_loc = (Lexing.dummy_pos, Lexing.dummy_pos)
 
-let rec flatten_nodes (l: node list): node list =
-  List.flatten (List.map flatten_node l)
-
-and flatten_node (node: node): node list =
-  match node with
-  | `Seq (_loc, l) -> flatten_nodes l
-  | x -> [x]
-
 let node_loc node =
   match node with
   | `Ident (loc, _, _)

--- a/src/cppo_types.ml
+++ b/src/cppo_types.ml
@@ -179,3 +179,23 @@ let rec is_whitespace_node node =
 
 and is_whitespace_nodes nodes =
   List.for_all is_whitespace_node nodes
+
+let is_not_whitespace_node node =
+  not (is_whitespace_node node)
+
+let dissolve (node : node) : node list =
+  match node with
+  | `Seq (_loc, nodes) ->
+      nodes
+  | _ ->
+      [node]
+
+let nodes_are_ident (nodes : node list) : (loc * string) option =
+  match List.filter is_not_whitespace_node nodes with
+  | [`Ident (loc, x, [])] ->
+      Some (loc, x)
+  | _ ->
+      None
+
+let node_is_ident (node : node) : (loc * string) option =
+  nodes_are_ident (dissolve node)

--- a/src/cppo_types.ml
+++ b/src/cppo_types.ml
@@ -120,7 +120,7 @@ and actuals =
 
 (* The body of a macro definition. *)
 and body =
-  node list
+  node
 
 
 let string_of_loc (pos1, pos2) =
@@ -180,10 +180,10 @@ let rec is_whitespace_node node =
   match node with
   | `Text (_, is_whitespace, _) ->
       is_whitespace
-  | `Seq (_loc, body) ->
-      is_whitespace_body body
+  | `Seq (_loc, nodes) ->
+      is_whitespace_nodes nodes
   | _ ->
       false
 
-and is_whitespace_body body =
-  List.for_all is_whitespace_node body
+and is_whitespace_nodes nodes =
+  List.for_all is_whitespace_node nodes

--- a/src/cppo_types.ml
+++ b/src/cppo_types.ml
@@ -153,3 +153,37 @@ and flatten_node (node: node): node list =
   match node with
   | `Seq (_loc, l) -> flatten_nodes l
   | x -> [x]
+
+let node_loc node =
+  match node with
+  | `Ident (loc, _, _)
+  | `Def (loc, _, _, _)
+  | `Undef (loc, _)
+  | `Include (loc, _)
+  | `Ext (loc, _, _)
+  | `Cond (loc, _, _, _)
+  | `Error (loc, _)
+  | `Warning (loc, _)
+  | `Text (loc, _, _)
+  | `Seq (loc, _)
+  | `Line (loc, _, _)
+  | `Current_line loc
+  | `Current_file loc
+      -> loc
+  | `Stringify _
+  | `Capitalize _
+  | `Concat (_, _)
+      -> dummy_loc
+           (* These cases are never produced by the parser. *)
+
+let rec is_whitespace_node node =
+  match node with
+  | `Text (_, is_whitespace, _) ->
+      is_whitespace
+  | `Seq (_loc, body) ->
+      is_whitespace_body body
+  | _ ->
+      false
+
+and is_whitespace_body body =
+  List.for_all is_whitespace_node body

--- a/src/cppo_types.mli
+++ b/src/cppo_types.mli
@@ -106,7 +106,7 @@ and actuals =
 
 (* The body of a macro definition. *)
 and body =
-  node list
+  node
 
 val dummy_loc : loc
 
@@ -119,5 +119,6 @@ val flatten_nodes : node list -> node list
 (* [node_loc] extracts the location of a node. *)
 val node_loc : node -> loc
 
+(* [is_whitespace_node] determines whether a node is just whitespace. *)
 val is_whitespace_node : node -> bool
-val is_whitespace_body : body -> bool
+val is_whitespace_nodes : node list -> bool

--- a/src/cppo_types.mli
+++ b/src/cppo_types.mli
@@ -19,6 +19,12 @@ type shape =
    which takes no parameters, and produces text. *)
 val base : shape
 
+(* Printing a shape. *)
+val print_shape : shape -> string
+
+(* Testing two shapes for equality. *)
+val same_shape : shape -> shape -> bool
+
 type bool_expr =
     [ `True
     | `False

--- a/src/cppo_types.mli
+++ b/src/cppo_types.mli
@@ -98,7 +98,7 @@ and formals =
 
 (* One actual macro argument. *)
 and actual =
-  node list
+  node
 
 (* A tuple of actual macro arguments. *)
 and actuals =

--- a/src/cppo_types.mli
+++ b/src/cppo_types.mli
@@ -59,7 +59,7 @@ type node =
     | `Error of (loc * string)
     | `Warning of (loc * string)
     | `Text of (loc * bool * string) (* bool is true for space tokens *)
-    | `Seq of node list
+    | `Seq of (loc * node list)
     | `Stringify of node
     | `Capitalize of node
     | `Concat of (node * node)

--- a/src/cppo_types.mli
+++ b/src/cppo_types.mli
@@ -114,8 +114,6 @@ val error : loc -> string -> _
 
 val warning : loc -> string -> unit
 
-val flatten_nodes : node list -> node list
-
 (* [node_loc] extracts the location of a node. *)
 val node_loc : node -> loc
 

--- a/src/cppo_types.mli
+++ b/src/cppo_types.mli
@@ -120,3 +120,8 @@ val node_loc : node -> loc
 (* [is_whitespace_node] determines whether a node is just whitespace. *)
 val is_whitespace_node : node -> bool
 val is_whitespace_nodes : node list -> bool
+
+(* [node_is_ident node] tests whether [node] is a single identifier,
+   possibly surrounded with whitespace, and (if successful) returns
+   this identifier as well as its location. *)
+val node_is_ident : node -> (loc * string) option

--- a/src/cppo_types.mli
+++ b/src/cppo_types.mli
@@ -6,6 +6,19 @@ exception Cppo_error of string
 type macro =
   string
 
+(* The shape of a macro.
+
+   The abstract syntax of shapes is τ ::= [τ, ..., τ].
+   That is, a macro takes a tuple of parameters, each
+   of which has a shape. The length of of this tuple
+   can be zero: this is the base case. *)
+type shape =
+  | Shape of shape list
+
+(* The base shape. This is the shape of a basic macro,
+   which takes no parameters, and produces text. *)
+val base : shape
+
 type bool_expr =
     [ `True
     | `False
@@ -67,9 +80,11 @@ type node =
     | `Current_line of loc
     | `Current_file of loc ]
 
-(* One formal macro parameter. *)
+(* A formal macro parameter consists of an identifier (the name of this
+   parameter) and a shape (the shape of this parameter). In the concrete
+   syntax, if the shape is omitted, then the base shape is assumed. *)
 and formal =
-  string
+  string * shape
 
 (* A tuple of formal macro parameters. *)
 and formals =

--- a/src/cppo_types.mli
+++ b/src/cppo_types.mli
@@ -115,3 +115,9 @@ val error : loc -> string -> _
 val warning : loc -> string -> unit
 
 val flatten_nodes : node list -> node list
+
+(* [node_loc] extracts the location of a node. *)
+val node_loc : node -> loc
+
+val is_whitespace_node : node -> bool
+val is_whitespace_body : body -> bool

--- a/test/arity_mismatch_indirect.cppo
+++ b/test/arity_mismatch_indirect.cppo
@@ -1,0 +1,3 @@
+#define ID(X) X
+#define APPLY(F : [.], X) F (* intentionally forgetting to apply F *)
+APPLY(ID, 42)

--- a/test/arity_mismatch_indirect.ref
+++ b/test/arity_mismatch_indirect.ref
@@ -1,0 +1,2 @@
+Error: File "arity_mismatch_indirect.cppo", line 2, characters 26-27
+Error: "F" expects 1 argument but is applied to 0 argument.

--- a/test/at_least_one_arg.ref
+++ b/test/at_least_one_arg.ref
@@ -1,2 +1,2 @@
-Error: File "at_least_one_arg.cppo", line 2, characters 0-13
+Error: File "at_least_one_arg.cppo", line 2, characters 12-13
 Error: At least one argument is required

--- a/test/at_least_one_arg.ref
+++ b/test/at_least_one_arg.ref
@@ -1,2 +1,2 @@
 Error: File "at_least_one_arg.cppo", line 2, characters 12-13
-Error: At least one argument is required
+Error: A macro must have at least one formal parameter

--- a/test/comment_in_formals.cppo
+++ b/test/comment_in_formals.cppo
@@ -1,0 +1,2 @@
+#define FOO(x, (* a comment *) y) x+y
+FOO(42, 23)

--- a/test/comment_in_formals.ref
+++ b/test/comment_in_formals.ref
@@ -1,0 +1,2 @@
+Error: File "comment_in_formals.cppo", line 1, characters 15-30
+Error: Invalid argument list

--- a/test/comment_in_formals.ref
+++ b/test/comment_in_formals.ref
@@ -1,2 +1,2 @@
 Error: File "comment_in_formals.cppo", line 1, characters 15-16
-Error: Invalid argument list
+Error: Invalid formal parameter: expected an identifier

--- a/test/comment_in_formals.ref
+++ b/test/comment_in_formals.ref
@@ -1,2 +1,2 @@
-Error: File "comment_in_formals.cppo", line 1, characters 15-30
+Error: File "comment_in_formals.cppo", line 1, characters 15-16
 Error: Invalid argument list

--- a/test/def.cppo
+++ b/test/def.cppo
@@ -1,0 +1,77 @@
+(* This macro application combinator provides call-by-value
+   semantics: the actual argument is evaluated up front and
+   its value is bound to a variable, which is passed as an
+   argument to the macro [F]. *)
+#def APPLY(F : [.], X : .)
+  (let __x = (X) in F(__x))
+    (* Multiple lines permitted; no backslash required. *)
+#enddef
+
+(* Some trivial tests. *)
+#define ID(X) X
+#define C     42
+let forty_one = APPLY(ID, 41)
+let forty_two = APPLY(ID, C )
+
+(* A [for]-loop macro. *)
+#def LOOP(start, finish, body : [.])
+(
+  for __index = start to finish-1 do
+    body(__index)
+  done
+)
+#enddef
+
+(* A [for]-loop macro that performs unrolling. *)
+#def UNROLLED_LOOP(start, finish, body : [.]) (
+  (* #define can be nested inside #def. *)
+  #define BODY(i) APPLY(body, i)
+  (* #def can be nested inside #def. *)
+  #def INCREMENT(i, k)
+    i := !i + k
+  #enddef
+  let __finish = (finish) in
+  let __index = ref (start) in
+  while !__index + 2 <= __finish do
+    BODY(!__index);
+    BODY(!__index + 1);
+    INCREMENT(__index, 2)
+  done;
+  while !__index < __finish do
+    BODY(!__index);
+    INCREMENT(__index, 1)
+  done
+)
+#enddef
+
+(* Iteration over an array, with a normal loop. *)
+let iter f a =
+  #define BODY(i) (f a.(i))
+  LOOP(0, Array.length a, BODY)
+  #undef BODY
+
+(* Iteration over an array, with an unrolled loop. *)
+let unrolled_iter f a =
+  #define BODY(i) (f a.(i))
+  UNROLLED_LOOP(0, Array.length a, BODY)
+  #undef BODY
+
+(* Printing an array, with a normal loop. *)
+let print_int_array a =
+  #define F(i) Printf.printf "%d" a.(i)
+  LOOP(0, Array.length a, F)
+
+(* A higher-order macro that produces a definition of [iter],
+   and accepts an arbitrary definition of the macro [LOOP]. *)
+#define BODY(i) (f a.(i))
+#def DEFINE_ITER(iter, LOOP : [..[.]])
+  let iter f a =
+  LOOP(0, Array.length a, BODY)
+#enddef
+#undef BODY
+
+(* Some noise, which does not affect the above definitions. *)
+#define BODY(i) "noise"
+
+DEFINE_ITER(iter, LOOP)
+DEFINE_ITER(unrolled_iter, UNROLLED_LOOP)

--- a/test/def.ref
+++ b/test/def.ref
@@ -1,0 +1,141 @@
+# 1 "def.cppo"
+(* This macro application combinator provides call-by-value
+   semantics: the actual argument is evaluated up front and
+   its value is bound to a variable, which is passed as an
+   argument to the macro [F]. *)
+
+# 10 "def.cppo"
+(* Some trivial tests. *)
+# 13 "def.cppo"
+let forty_one = 
+# 13 "def.cppo"
+                
+  (let __x = ( 41) in  __x )
+    (* Multiple lines permitted; no backslash required. *)
+ 
+# 14 "def.cppo"
+let forty_two = 
+# 14 "def.cppo"
+                
+  (let __x = (      42  ) in  __x )
+    (* Multiple lines permitted; no backslash required. *)
+ 
+
+# 16 "def.cppo"
+(* A [for]-loop macro. *)
+
+# 25 "def.cppo"
+(* A [for]-loop macro that performs unrolling. *)
+
+# 47 "def.cppo"
+(* Iteration over an array, with a normal loop. *)
+let iter f a =
+  
+# 50 "def.cppo"
+  
+(
+  for __index = 0 to  Array.length a-1 do
+     (f a.(__index)) 
+  done
+)
+ 
+
+# 53 "def.cppo"
+(* Iteration over an array, with an unrolled loop. *)
+let unrolled_iter f a =
+  
+# 56 "def.cppo"
+   (
+  (* #define can be nested inside #def. *)
+  (* #def can be nested inside #def. *)
+  let __finish = ( Array.length a) in
+  let __index = ref (0) in
+  while !__index + 2 <= __finish do
+     
+  (let __x = ( !__index) in  (f a.(__x)) )
+    (* Multiple lines permitted; no backslash required. *)
+  ;
+     
+  (let __x = ( !__index + 1) in  (f a.(__x)) )
+    (* Multiple lines permitted; no backslash required. *)
+  ;
+    
+    __index := !__index +  2
+ 
+  done;
+  while !__index < __finish do
+     
+  (let __x = ( !__index) in  (f a.(__x)) )
+    (* Multiple lines permitted; no backslash required. *)
+  ;
+    
+    __index := !__index +  1
+ 
+  done
+)
+ 
+
+# 59 "def.cppo"
+(* Printing an array, with a normal loop. *)
+let print_int_array a =
+  
+# 62 "def.cppo"
+  
+(
+  for __index = 0 to  Array.length a-1 do
+     Printf.printf "%d" a.(__index) 
+  done
+)
+ 
+
+# 64 "def.cppo"
+(* A higher-order macro that produces a definition of [iter],
+   and accepts an arbitrary definition of the macro [LOOP]. *)
+
+# 73 "def.cppo"
+(* Some noise, which does not affect the above definitions. *)
+
+# 76 "def.cppo"
+
+  let iter f a =
+  
+(
+  for __index = 0 to  Array.length a-1 do
+     (f a.(__index)) 
+  done
+)
+ 
+ 
+# 77 "def.cppo"
+
+  let unrolled_iter f a =
+   (
+  (* #define can be nested inside #def. *)
+  (* #def can be nested inside #def. *)
+  let __finish = ( Array.length a) in
+  let __index = ref (0) in
+  while !__index + 2 <= __finish do
+     
+  (let __x = ( !__index) in  (f a.(__x)) )
+    (* Multiple lines permitted; no backslash required. *)
+  ;
+     
+  (let __x = ( !__index + 1) in  (f a.(__x)) )
+    (* Multiple lines permitted; no backslash required. *)
+  ;
+    
+    __index := !__index +  2
+ 
+  done;
+  while !__index < __finish do
+     
+  (let __x = ( !__index) in  (f a.(__x)) )
+    (* Multiple lines permitted; no backslash required. *)
+  ;
+    
+    __index := !__index +  1
+ 
+  done
+)
+ 
+ 

--- a/test/define_on_last_line.cppo
+++ b/test/define_on_last_line.cppo
@@ -1,0 +1,2 @@
+(* This #define is NOT ended by a new line, but is nevertheless accepted. *)
+#define TWICE(e) e + e

--- a/test/dune
+++ b/test/dune
@@ -205,6 +205,15 @@
       (action (diff expect_ident.ref expect_ident.err)))
 
 (rule
+ (targets expect_ident_empty.err)
+ (deps (:< expect_ident_empty.cppo))
+ (action (with-stderr-to %{targets}
+   (with-accepted-exit-codes (not 0) (run %{bin:cppo} %{<})))))
+
+(rule (alias runtest) (package cppo)
+      (action (diff expect_ident_empty.ref expect_ident_empty.err)))
+
+(rule
  (targets undefined.err)
  (deps (:< undefined.cppo))
  (action (with-stderr-to %{targets}

--- a/test/dune
+++ b/test/dune
@@ -96,6 +96,11 @@
  (deps (:< higher_order_macros.cppo))
  (action (with-stdout-to %{targets} (run %{bin:cppo} %{<}))))
 
+(rule
+ (targets include_define_on_last_line.out)
+ (deps (:< include_define_on_last_line.cppo) define_on_last_line.cppo)
+ (action (with-stdout-to %{targets} (run %{bin:cppo} %{<}))))
+
 (rule (alias runtest) (package cppo)
       (action (diff ext.ref ext.out)))
 
@@ -128,6 +133,9 @@
 
 (rule (alias runtest) (package cppo)
       (action (diff higher_order_macros.ref higher_order_macros.out)))
+
+(rule (alias runtest) (package cppo)
+      (action (diff include_define_on_last_line.ref include_define_on_last_line.out)))
 
 ;; ---------------------------------------------------------------------------
 ;; Negative tests.

--- a/test/dune
+++ b/test/dune
@@ -230,3 +230,12 @@
 
 (rule (alias runtest) (package cppo)
       (action (diff shape_mismatch.ref shape_mismatch.err)))
+
+(rule
+ (targets int_expansion_error.err)
+ (deps (:< int_expansion_error.cppo))
+ (action (with-stderr-to %{targets}
+   (with-accepted-exit-codes (not 0) (run %{bin:cppo} %{<})))))
+
+(rule (alias runtest) (package cppo)
+      (action (diff int_expansion_error.ref int_expansion_error.err)))

--- a/test/dune
+++ b/test/dune
@@ -101,6 +101,11 @@
  (deps (:< include_define_on_last_line.cppo) define_on_last_line.cppo)
  (action (with-stdout-to %{targets} (run %{bin:cppo} %{<}))))
 
+(rule
+ (targets def.out)
+ (deps (:< def.cppo))
+ (action (with-stdout-to %{targets} (run %{bin:cppo} %{<}))))
+
 (rule (alias runtest) (package cppo)
       (action (diff ext.ref ext.out)))
 
@@ -136,6 +141,9 @@
 
 (rule (alias runtest) (package cppo)
       (action (diff include_define_on_last_line.ref include_define_on_last_line.out)))
+
+(rule (alias runtest) (package cppo)
+      (action (diff def.ref def.out)))
 
 ;; ---------------------------------------------------------------------------
 ;; Negative tests.
@@ -247,3 +255,21 @@
 
 (rule (alias runtest) (package cppo)
       (action (diff int_expansion_error.ref int_expansion_error.err)))
+
+(rule
+ (targets extraneous_enddef.err)
+ (deps (:< extraneous_enddef.cppo))
+ (action (with-stderr-to %{targets}
+   (with-accepted-exit-codes (not 0) (run %{bin:cppo} %{<})))))
+
+(rule (alias runtest) (package cppo)
+      (action (diff extraneous_enddef.ref extraneous_enddef.err)))
+
+(rule
+ (targets missing_enddef.err)
+ (deps (:< missing_enddef.cppo))
+ (action (with-stderr-to %{targets}
+   (with-accepted-exit-codes (not 0) (run %{bin:cppo} %{<})))))
+
+(rule (alias runtest) (package cppo)
+      (action (diff missing_enddef.ref missing_enddef.err)))

--- a/test/dune
+++ b/test/dune
@@ -168,3 +168,12 @@
 
 (rule (alias runtest) (package cppo)
       (action (diff at_least_one_arg.ref at_least_one_arg.err)))
+
+(rule
+ (targets comment_in_formals.err)
+ (deps (:< comment_in_formals.cppo))
+ (action (with-stderr-to %{targets}
+   (with-accepted-exit-codes (not 0) (run %{bin:cppo} %{<})))))
+
+(rule (alias runtest) (package cppo)
+      (action (diff comment_in_formals.ref comment_in_formals.err)))

--- a/test/dune
+++ b/test/dune
@@ -185,3 +185,39 @@
 
 (rule (alias runtest) (package cppo)
       (action (diff comment_in_formals.ref comment_in_formals.err)))
+
+(rule
+ (targets arity_mismatch_indirect.err)
+ (deps (:< arity_mismatch_indirect.cppo))
+ (action (with-stderr-to %{targets}
+   (with-accepted-exit-codes (not 0) (run %{bin:cppo} %{<})))))
+
+(rule (alias runtest) (package cppo)
+      (action (diff arity_mismatch_indirect.ref arity_mismatch_indirect.err)))
+
+(rule
+ (targets expect_ident.err)
+ (deps (:< expect_ident.cppo))
+ (action (with-stderr-to %{targets}
+   (with-accepted-exit-codes (not 0) (run %{bin:cppo} %{<})))))
+
+(rule (alias runtest) (package cppo)
+      (action (diff expect_ident.ref expect_ident.err)))
+
+(rule
+ (targets undefined.err)
+ (deps (:< undefined.cppo))
+ (action (with-stderr-to %{targets}
+   (with-accepted-exit-codes (not 0) (run %{bin:cppo} %{<})))))
+
+(rule (alias runtest) (package cppo)
+      (action (diff undefined.ref undefined.err)))
+
+(rule
+ (targets shape_mismatch.err)
+ (deps (:< shape_mismatch.cppo))
+ (action (with-stderr-to %{targets}
+   (with-accepted-exit-codes (not 0) (run %{bin:cppo} %{<})))))
+
+(rule (alias runtest) (package cppo)
+      (action (diff shape_mismatch.ref shape_mismatch.err)))

--- a/test/dune
+++ b/test/dune
@@ -91,6 +91,11 @@
  (deps (:< lexical.cppo))
  (action (with-stdout-to %{targets} (run %{bin:cppo} %{<}))))
 
+(rule
+ (targets higher_order_macros.out)
+ (deps (:< higher_order_macros.cppo))
+ (action (with-stdout-to %{targets} (run %{bin:cppo} %{<}))))
+
 (rule (alias runtest) (package cppo)
       (action (diff ext.ref ext.out)))
 
@@ -120,6 +125,9 @@
 
 (rule (alias runtest) (package cppo)
       (action (diff lexical.ref lexical.out)))
+
+(rule (alias runtest) (package cppo)
+      (action (diff higher_order_macros.ref higher_order_macros.out)))
 
 ;; ---------------------------------------------------------------------------
 ;; Negative tests.

--- a/test/expect_ident.cppo
+++ b/test/expect_ident.cppo
@@ -1,0 +1,6 @@
+let id x = x
+#define ID(X) X
+#define APPLY(F : [.], X) F(X)
+APPLY(ID(id), 42)
+  (* invalid because APPLY expects a macro as an argument:
+     ID would be a valid argument; ID(id) is not. *)

--- a/test/expect_ident.ref
+++ b/test/expect_ident.ref
@@ -1,0 +1,2 @@
+Error: File "expect_ident.cppo", line 4, characters 6-12
+Error: The name of a macro is expected in this position

--- a/test/expect_ident_empty.cppo
+++ b/test/expect_ident_empty.cppo
@@ -1,0 +1,6 @@
+let id x = x
+#define ID(X) X
+#define APPLY(F : [.], X) F(X)
+APPLY(, 42)
+  (* invalid because APPLY expects a macro as an argument:
+     an empty argument is not allowed. *)

--- a/test/expect_ident_empty.ref
+++ b/test/expect_ident_empty.ref
@@ -1,2 +1,2 @@
-Error: File "expect_ident_empty.cppo", line 4, characters 0-11
+Error: File "expect_ident_empty.cppo", line 4, characters 6-6
 Error: The name of a macro is expected in this position

--- a/test/expect_ident_empty.ref
+++ b/test/expect_ident_empty.ref
@@ -1,0 +1,2 @@
+Error: File "expect_ident_empty.cppo", line 4, characters 0-11
+Error: The name of a macro is expected in this position

--- a/test/extraneous_enddef.cppo
+++ b/test/extraneous_enddef.cppo
@@ -1,0 +1,4 @@
+#define FOO \
+  42
+(* The following #enddef is extraneous; it should not be there. *)
+#enddef

--- a/test/extraneous_enddef.ref
+++ b/test/extraneous_enddef.ref
@@ -1,2 +1,2 @@
-Error: File "extraneous_enddef.cppo", line 4, characters 7-8
+Error: File "extraneous_enddef.cppo", line 4, characters 0-8
 Error: syntax error

--- a/test/extraneous_enddef.ref
+++ b/test/extraneous_enddef.ref
@@ -1,0 +1,2 @@
+Error: File "extraneous_enddef.cppo", line 4, characters 7-8
+Error: syntax error

--- a/test/higher_order_macros.cppo
+++ b/test/higher_order_macros.cppo
@@ -1,0 +1,64 @@
+(* This macro application combinator provides call-by-value
+   semantics: the actual argument is evaluated up front and
+   its value is bound to a variable, which is passed as an
+   argument to the macro [F]. *)
+#define APPLY(F : [.], X : .)(let __x = (X) in F(__x))
+
+(* Some trivial tests. *)
+#define ID(X) X
+#define C     42
+let forty_one = APPLY(ID, 41)
+let forty_two = APPLY(ID, C )
+
+(* A [for]-loop macro. *)
+#define LOOP(start, finish, body : [.]) (\
+  for __index = start to finish-1 do\
+    body(__index)\
+  done\
+)
+
+(* A [for]-loop macro that performs unrolling. *)
+#define UNROLLED_LOOP(start, finish, body : [.]) (\
+  let __finish = (finish) in\
+  let __index = ref (start) in\
+  while !__index + 2 <= __finish do\
+    APPLY(body, !__index);\
+    APPLY(body, !__index + 1);\
+    __index := !__index + 2\
+  done;\
+  while !__index < __finish do\
+    APPLY(body, !__index);\
+    __index := !__index + 1\
+  done\
+)
+
+(* Iteration over an array, with a normal loop. *)
+let iter f a =
+  #define BODY(i) (f a.(i))
+  LOOP(0, Array.length a, BODY)
+  #undef BODY
+
+(* Iteration over an array, with an unrolled loop. *)
+let unrolled_iter f a =
+  #define BODY(i) (f a.(i))
+  UNROLLED_LOOP(0, Array.length a, BODY)
+  #undef BODY
+
+(* Printing an array, with a normal loop. *)
+let print_int_array a =
+  #define F(i) Printf.printf "%d" a.(i)
+  LOOP(0, Array.length a, F)
+
+(* A higher-order macro that produces a definition of [iter],
+   and accepts an arbitrary definition of the macro [LOOP]. *)
+#define BODY(i) (f a.(i))
+#define DEFINE_ITER(iter, LOOP : [..[.]]) \
+  let iter f a = \
+  LOOP(0, Array.length a, BODY)
+#undef BODY
+
+(* Some noise, which does not affect the above definitions. *)
+#define BODY(i) "noise"
+
+DEFINE_ITER(iter, LOOP)
+DEFINE_ITER(unrolled_iter, UNROLLED_LOOP)

--- a/test/higher_order_macros.ref
+++ b/test/higher_order_macros.ref
@@ -1,0 +1,95 @@
+# 1 "higher_order_macros.cppo"
+(* This macro application combinator provides call-by-value
+   semantics: the actual argument is evaluated up front and
+   its value is bound to a variable, which is passed as an
+   argument to the macro [F]. *)
+
+# 7 "higher_order_macros.cppo"
+(* Some trivial tests. *)
+# 10 "higher_order_macros.cppo"
+let forty_one = 
+# 10 "higher_order_macros.cppo"
+                (let __x = ( 41) in  __x ) 
+# 11 "higher_order_macros.cppo"
+let forty_two = 
+# 11 "higher_order_macros.cppo"
+                (let __x = (      42  ) in  __x ) 
+
+# 13 "higher_order_macros.cppo"
+(* A [for]-loop macro. *)
+
+# 20 "higher_order_macros.cppo"
+(* A [for]-loop macro that performs unrolling. *)
+
+# 35 "higher_order_macros.cppo"
+(* Iteration over an array, with a normal loop. *)
+let iter f a =
+  
+# 38 "higher_order_macros.cppo"
+   (
+  for __index = 0 to  Array.length a-1 do
+     (f a.(__index)) 
+  done
+) 
+
+# 41 "higher_order_macros.cppo"
+(* Iteration over an array, with an unrolled loop. *)
+let unrolled_iter f a =
+  
+# 44 "higher_order_macros.cppo"
+   (
+  let __finish = ( Array.length a) in
+  let __index = ref (0) in
+  while !__index + 2 <= __finish do
+    (let __x = ( !__index) in  (f a.(__x)) ) ;
+    (let __x = ( !__index + 1) in  (f a.(__x)) ) ;
+    __index := !__index + 2
+  done;
+  while !__index < __finish do
+    (let __x = ( !__index) in  (f a.(__x)) ) ;
+    __index := !__index + 1
+  done
+) 
+
+# 47 "higher_order_macros.cppo"
+(* Printing an array, with a normal loop. *)
+let print_int_array a =
+  
+# 50 "higher_order_macros.cppo"
+   (
+  for __index = 0 to  Array.length a-1 do
+     Printf.printf "%d" a.(__index) 
+  done
+) 
+
+# 52 "higher_order_macros.cppo"
+(* A higher-order macro that produces a definition of [iter],
+   and accepts an arbitrary definition of the macro [LOOP]. *)
+
+# 60 "higher_order_macros.cppo"
+(* Some noise, which does not affect the above definitions. *)
+
+# 63 "higher_order_macros.cppo"
+ 
+  let iter f a = 
+   (
+  for __index = 0 to  Array.length a-1 do
+     (f a.(__index)) 
+  done
+)  
+# 64 "higher_order_macros.cppo"
+ 
+  let unrolled_iter f a = 
+   (
+  let __finish = ( Array.length a) in
+  let __index = ref (0) in
+  while !__index + 2 <= __finish do
+    (let __x = ( !__index) in  (f a.(__x)) ) ;
+    (let __x = ( !__index + 1) in  (f a.(__x)) ) ;
+    __index := !__index + 2
+  done;
+  while !__index < __finish do
+    (let __x = ( !__index) in  (f a.(__x)) ) ;
+    __index := !__index + 1
+  done
+)  

--- a/test/include_define_on_last_line.cppo
+++ b/test/include_define_on_last_line.cppo
@@ -1,0 +1,3 @@
+#include "define_on_last_line.cppo"
+(* Check that the definition of TWICE has been accepted: *)
+let f x = TWICE(x)

--- a/test/include_define_on_last_line.ref
+++ b/test/include_define_on_last_line.ref
@@ -1,0 +1,7 @@
+# 1 "define_on_last_line.cppo"
+(* This #define is NOT ended by a new line, but is nevertheless accepted. *)
+# 2 "include_define_on_last_line.cppo"
+(* Check that the definition of TWICE has been accepted: *)
+let f x = 
+# 3 "include_define_on_last_line.cppo"
+           x + x 

--- a/test/int_expansion_error.cppo
+++ b/test/int_expansion_error.cppo
@@ -1,0 +1,4 @@
+#define FOO 3+3
+#if FOO = 0
+  let x = "Hello"
+#endif

--- a/test/int_expansion_error.ref
+++ b/test/int_expansion_error.ref
@@ -1,0 +1,4 @@
+Error: File "int_expansion_error.cppo", line 2, characters 4-7
+Error: Variable FOO found in cppo boolean expression must expand
+into an int literal, into a tuple of int literals,
+or into a variable with the same properties.

--- a/test/missing_enddef.cppo
+++ b/test/missing_enddef.cppo
@@ -1,0 +1,12 @@
+(* A common problem: *)
+
+#def TWICE(e)
+  e + e
+(* missing #enddef here *)
+
+let f x =
+  TWICE(x)
+
+(* The error is detected by the parser at the end of the file,
+   but we are able to report the location of the #def as the
+   source of the problem. *)

--- a/test/missing_enddef.ref
+++ b/test/missing_enddef.ref
@@ -1,0 +1,2 @@
+Error: File "missing_enddef.cppo", line 3, characters 0-13
+Error: This #def is never closed: perhaps #enddef is missing

--- a/test/shape_mismatch.cppo
+++ b/test/shape_mismatch.cppo
@@ -1,0 +1,5 @@
+#define FOO 24
+#define APPLY(F : [.], X) F(X)
+APPLY(FOO, 42)
+  (* invalid because APPLY expects a macro of type [.]
+     but FOO has type . *)

--- a/test/shape_mismatch.ref
+++ b/test/shape_mismatch.ref
@@ -1,0 +1,3 @@
+Error: File "shape_mismatch.cppo", line 3, characters 6-9
+Error: A macro of type [.] was expected, but
+       a macro of type . was provided

--- a/test/undefined.cppo
+++ b/test/undefined.cppo
@@ -1,0 +1,4 @@
+#define APPLY(F : [.], X) F(X)
+APPLY(FOO, 42)
+  (* invalid because APPLY expects a macro as an argument:
+     but FOO is not defined. *)

--- a/test/undefined.ref
+++ b/test/undefined.ref
@@ -1,0 +1,2 @@
+Error: File "undefined.cppo", line 2, characters 6-9
+Error: The macro 'FOO' is not defined


### PR DESCRIPTION
Hello,

This PR proposes:

* Higher-order macros. This does not break any existing code: the formal parameters of a higher-order macro must be annotated with their types, and there is a new syntax for this purpose.

* Macro definitions with explicit delimiters, `#def` and `#enddef`. This allows multi-line macros (without backslashes) and nested macros. This is unlikely to break any existing code, but it does introduce two new directives.

* (minor) `#define` on the last line of a file, without a newline, is now accepted. (It used to be an error. Accepting it allows me to produce a reliable error message when `#def` does not have a matching `#enddef`.)

* (minor) Better locations for some syntax error messages, by systematically using `long_loc` instead of `loc`.

The new features are documented in [README.md](README.md).

Some examples of the use of higher-order macros appear in the example file [test/higher_order_macros.cppo](test/higher_order_macros.cppo). Similar examples, which also take advantage of `#def ... #enddef`, appear in [test/def.cppo](test/def.cppo).

Here are some more ideas, about which I would welcome the opinion of the `cppo` maintainers. I believe that each of these ideas would be easy to implement:

* I am tempted to introduce `#scope` and `#endscope` delimiters, so as to allow limiting the scope of a macro definition. I believe that this would often remove the need to use `#undef`, which is quite painful.

* The use of higher-order macros is currently somewhat heavy, because the actual argument must be a *named* macro, so, at the call site, it must be locally defined (and possibly undefined). I am tempted to introduce a syntax for macro-abstractions, which would be allowed to appear as actual arguments to higher-order macros. The syntax would be `#lambda(formals) ... #endlambda`. Perhaps, for greater conciseness, it would be necessary to allow `#lambda` and `#endlambda` to be recognized as directives even if they are *not* placed at the beginning of a line.

* In order to improve hygiene in higher-order macros, I would like to introduce a new directive `#fresh x y`, which behaves like `#define x <some fresh name based on y>`. A globally fresh name would be obtained by combining the prefix `y` with a numeric suffix obtained by reading and incrementing a global counter.

* Because `#undef` is heavy, I have been tempted to add a command-line switch `--allow-shadowing`, which allows a new macro definition to shadow an existing definition. That said, perhaps `#scope ... #endscope` would lessen the need for this feature.
