### PR TITLE
Refactoring

### DIFF
--- a/src/cppo_eval.ml
+++ b/src/cppo_eval.ml
@@ -556,60 +556,77 @@ and expand_list ?(top = false) g env l =
    an identifier [`Ident (loc, name, actuals)]. *)
 and expand_ident ~top g env0 loc name (actuals : actuals) =
 
+  (* Test whether there exists a definition for the macro [name]. *)
   let def = find_opt name env0 in
+  match def with
+  | None ->
+      expand_ordinary_ident g env0 loc name actuals
+  | Some def ->
+      expand_macro_application ~top g env0 loc name actuals def
+
+(* [expand_ordinary_ident] is the special case of [expand_ident] where
+   it turns out that the identifier [name] is not a macro. *)
+and expand_ordinary_ident g env0 loc name actuals =
+
   let g =
-    if top && def <> None || g.call_loc == dummy_loc then
+    if g.call_loc == dummy_loc then
       { g with call_loc = loc }
     else g
   in
 
   let enable_loc0 = !(g.enable_loc) in
 
-  if def <> None then (
-    g.require_location := true;
+  (* There is no definition for the macro [name], so this is not
+     a macro application after all. Transform it back into text,
+     and process it. *)
+  let env = expand_list g env0 (text loc name actuals) in
 
-    if not g.show_exact_locations then (
-      (* error reports will point more or less to the point
-         where the code is included rather than the source location
-         of the macro definition *)
-      maybe_print_location g (fst loc);
-      g.enable_loc := false
-    )
-  );
-
-  let env =
-    match def with
-
-    | None ->
-        (* There is no definition for the macro [name], so this is not
-           a macro application after all. Transform it back into text,
-           and process it. *)
-        expand_list g env0 (text loc name actuals)
-
-    | Some (EDef (_loc, formals, body, env)) ->
-        (* There is a definition for the macro [name], so this is a
-           macro application. *)
-        check_arity loc name formals actuals;
-        (* Extend the macro's captured environment [env] with bindings of
-           formals to actuals. Each actual captures the environment [env0]
-           that exists here, at the macro application site. *)
-        let env = bind_many formals (loc, actuals, env0) env in
-        (* Process the macro's body in this extended environment. *)
-        let (_ : env) = expand_node g env body in
-        (* Continue with our original environment. *)
-        env0
-
-  in
-
-  if def = None then
-    g.require_location := false
-  else
-    g.require_location := true;
+  g.require_location := false;
 
   (* restore initial setting *)
   g.enable_loc := enable_loc0;
 
   env
+
+(* [expand_macro_application] is the special case of [expand_ident] where
+   it turns out that the identifier [name] is a macro. *)
+and expand_macro_application ~top g env0 loc name actuals def =
+
+  let g =
+    if top || g.call_loc == dummy_loc then
+      { g with call_loc = loc }
+    else g
+  in
+
+  let enable_loc0 = !(g.enable_loc) in
+
+  g.require_location := true;
+
+  if not g.show_exact_locations then (
+    (* error reports will point more or less to the point
+       where the code is included rather than the source location
+       of the macro definition *)
+    maybe_print_location g (fst loc);
+    g.enable_loc := false
+  );
+
+  let EDef (_loc, formals, body, env) = def in
+  (* Check that this macro is applied to a correct number of arguments. *)
+  check_arity loc name formals actuals;
+  (* Extend the macro's captured environment [env] with bindings of
+     formals to actuals. Each actual captures the environment [env0]
+     that exists here, at the macro application site. *)
+  let env = bind_many formals (loc, actuals, env0) env in
+  (* Process the macro's body in this extended environment. *)
+  let (_ : env) = expand_node g env body in
+
+  g.require_location := true;
+
+  (* restore initial setting *)
+  g.enable_loc := enable_loc0;
+
+  (* Continue with our original environment. *)
+  env0
 
 and expand_node ?(top = false) g env0 (x : node) =
   match x with

--- a/src/cppo_eval.ml
+++ b/src/cppo_eval.ml
@@ -349,7 +349,8 @@ let rec eval_bool env (x : bool_expr) =
 type globals = {
   call_loc : Cppo_types.loc;
     (* location used to set the value of
-       __FILE__ and __LINE__ global variables *)
+       __FILE__ and __LINE__ global variables;
+       also used in the expansion of CONCAT *)
 
   mutable buf : Buffer.t;
     (* buffer where the output is written *)

--- a/src/cppo_eval.ml
+++ b/src/cppo_eval.ml
@@ -585,8 +585,6 @@ and expand_ordinary_ident g env0 loc name actuals =
      and process it. *)
   let env = expand_list g env0 (text loc name actuals) in
 
-  g.require_location := false;
-
   env
 
 (* [expand_macro_application] is the special case of [expand_ident] where

--- a/src/cppo_eval.ml
+++ b/src/cppo_eval.ml
@@ -567,20 +567,12 @@ and expand_ident ~top g env0 loc name (actuals : actuals) =
   let def = find_opt name env0 in
   match def with
   | None ->
-      expand_ordinary_ident g env0 loc name actuals
+      (* There is no definition for the macro [name], so this is not
+         a macro application after all. Transform it back into text,
+         and process it. *)
+      expand_list g env0 (text loc name actuals)
   | Some def ->
       expand_macro_application ~top g env0 loc name actuals def
-
-(* [expand_ordinary_ident] is the special case of [expand_ident] where
-   it turns out that the identifier [name] is not a macro. *)
-and expand_ordinary_ident g env0 loc name actuals =
-
-  (* There is no definition for the macro [name], so this is not
-     a macro application after all. Transform it back into text,
-     and process it. *)
-  let env = expand_list g env0 (text loc name actuals) in
-
-  env
 
 (* [expand_macro_application] is the special case of [expand_ident] where
    it turns out that the identifier [name] is a macro. *)

--- a/src/cppo_eval.ml
+++ b/src/cppo_eval.ml
@@ -575,12 +575,6 @@ and expand_ident ~top g env0 loc name (actuals : actuals) =
    it turns out that the identifier [name] is not a macro. *)
 and expand_ordinary_ident g env0 loc name actuals =
 
-  let g =
-    if g.call_loc == dummy_loc then
-      { g with call_loc = loc }
-    else g
-  in
-
   (* There is no definition for the macro [name], so this is not
      a macro application after all. Transform it back into text,
      and process it. *)

--- a/src/cppo_eval.ml
+++ b/src/cppo_eval.ml
@@ -580,8 +580,6 @@ and expand_ordinary_ident g env0 loc name actuals =
     else g
   in
 
-  preserving_enable_loc g @@ fun () ->
-
   (* There is no definition for the macro [name], so this is not
      a macro application after all. Transform it back into text,
      and process it. *)

--- a/src/cppo_lexer.mll
+++ b/src/cppo_lexer.mll
@@ -223,7 +223,7 @@ and directive e = parse
       { let xs = [] in
         DEF (long_loc e, id, xs) }
 
-  (* #def is identical to #define, except it does not set [e.directive],
+  (* #def is identical to #define, except it does not set [e.in_directive],
      so backslashes and newlines do not receive special treatment. The
      end of the macro definition must be explicitly signaled by #enddef. *)
   | blank* "def" dblank1 (ident as id) "("

--- a/src/cppo_types.ml
+++ b/src/cppo_types.ml
@@ -146,7 +146,7 @@ let warning loc s =
 
 let dummy_loc = (Lexing.dummy_pos, Lexing.dummy_pos)
 
-let node_loc node =
+let node_loc (node : node) : loc =
   match node with
   | `Ident (loc, _, _)
   | `Def (loc, _, _, _)


### PR DESCRIPTION
This PR introduces the functions `expand_ident` and `expand_macro_application` so as to clarify how identifiers are treated by `cppo`. In particular, in the case where an identifier is *not* a macro, the code is significantly simpler than before; it is now clear that such an identifier is treated as text.

There should be no change in functionality.

I wanted to propose this simplification before introducing support for `#scope ... #endscope`.
