### PR TITLE
Add support for local scopes (`#scope ... #endscope`)

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,6 @@
-## v1.7.1 (2024-??-??)
+## v1.8.0 (2024-??-??)
+- [+ui] A scope, delimited by `#scope ... #endscope`,
+        limits the effect of `#define`, `#def ... #enddef`, and `#undef`.
 - [bug] Fix `cppo -version`, which used to print a blank line (#92).
 
 ## v1.7.0 (2024-08-22)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ by a valid directive name or by a number:
 
 ```ocaml
 BLANK* "#" BLANK* ("def"|"enddef"|"define"|"undef"
+                  |"scope"|"endscope"
                   |"if"|"ifdef"|"ifndef"|"else"|"elif"|"endif"
                   |"include"
                   |"warning"|"error"
@@ -285,6 +286,25 @@ This code is expanded into:
 ```ocaml
 let forty_two =
    (let x = (1+2+3+4+5+6) in (x + x))
+```
+
+Scopes
+------
+When a block of text is delimited by `#scope ... #endscope`,
+all macro definitions (`#define`, `#def ... #enddef`)
+and undefinitions (`#undef`)
+become local:
+they take effect only within this block.
+
+```ocaml
+(* Here, assume that the macro FOO is not defined. *)
+#scope
+#define FOO "FOO is now defined"
+let x = FOO (* FOO expands to "FOO is now defined" *)
+#endscope
+(* Here, the macro FOO is again not defined. *)
+#define FOO 42
+let y = FOO (* FOO expands to 42 *)
 ```
 
 Conditionals

--- a/README.md
+++ b/README.md
@@ -642,6 +642,25 @@ and`.mlpack` files.  The following tags are available:
 * `cppo_V_OCAML` ≡ `-V OCAML:VERSION`, where `VERSION`
    is the version of OCaml that ocamlbuild uses.
 
+Balancing delimiters
+--------------------
+
+All delimiters,
+including scope delimiters (`#scope` and `#endscope`),
+delimiters of macro definitions (`#def` and `#enddef`),
+and delimiters of conditional constructs (`#if`, `#endif`, etc.),
+must be used in a well-balanced manner.
+
+This requirement does *not* apply separately to each category of delimiters.
+instead, it applies to all categories of delimiters at once.
+This is a stricter requirement.
+Thus, for example, `#scope` cannot be followed with `#endif`,
+and `#if` cannot be followed with `#endscope`.
+In other words,
+a scope cannot contain a fragment of a conditional construct,
+and a conditional construct cannot contain a fragment of a macro definition.
+
+
 Detailed command-line usage and options
 ---------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -307,6 +307,21 @@ let x = FOO (* FOO expands to "FOO is now defined" *)
 let y = FOO (* FOO expands to 42 *)
 ```
 
+Scopes can be nested,
+as illustrated by this example:
+
+```ocaml
+#scope
+  #define HELLO "Hello, "
+  #scope
+    #define MAN "man"
+    let message1 = HELLO ^ MAN
+  #endscope
+  (* Here, MAN is no longer defined, but HELLO still is. *)
+  let message2 = HELLO ^ "world"
+#endscope
+```
+
 Conditionals
 ------------
 

--- a/src/cppo_eval.ml
+++ b/src/cppo_eval.ml
@@ -624,6 +624,14 @@ and expand_node ?(top = false) g env0 (x : node) =
         else
           M.add name (EDef (loc, formals, body, env0)) env0
 
+    | `Scope body ->
+        (* A [body] is just a [node]. We expand this node, and drop
+           the resulting environment; instead, we return the current
+           environment. *)
+        let env = expand_node ~top g env0 body in
+        ignore env;
+        env0
+
     | `Undef (loc, name) ->
         g.require_location := true;
         if is_reserved name then

--- a/src/cppo_lexer.mll
+++ b/src/cppo_lexer.mll
@@ -249,6 +249,18 @@ and directive e = parse
       { blank_until_eol e lexbuf;
         UNDEF (long_loc e, id) }
 
+  (* #scope opens a block, which we expect will be ended by #endscope.
+     It does not set [e.in_directive], so backslashes and newlines do
+     not receive special treatment. *)
+  | blank* "scope" dblank0
+      { e.in_directive <- false;
+        SCOPE (long_loc e) }
+
+  (* #endscope ends a block. *)
+  | blank* "endscope"
+      { blank_until_eol e lexbuf;
+        ENDSCOPE (long_loc e) }
+
   | blank* "if" dblank1    { e.lexer <- `Test;
                              IF (long_loc e) }
   | blank* "elif" dblank1  { e.lexer <- `Test;

--- a/src/cppo_parser.mly
+++ b/src/cppo_parser.mly
@@ -8,7 +8,7 @@
 %token < Cppo_types.loc * string option * int > LINE
 %token < Cppo_types.loc * Cppo_types.bool_expr > IFDEF
 %token < Cppo_types.loc * string * string > EXT
-%token < Cppo_types.loc > ENDEF IF ELIF ELSE ENDIF ENDTEST
+%token < Cppo_types.loc > ENDEF SCOPE ENDSCOPE IF ELIF ELSE ENDIF ENDTEST
 
 /* Boolean expressions in #if/#elif directives */
 %token TRUE FALSE DEFINED NOT AND OR EQ LT GT NE LE GE
@@ -134,6 +134,16 @@ node:
                   error loc "This #def is never closed: perhaps #enddef is missing" }
                 /* We include this rule in order to produce a good error message
                    when a #def has no matching #enddef. */
+
+| SCOPE body ENDSCOPE
+                { let body = `Seq $2 in
+                  `Scope body }
+
+| SCOPE body EOF
+                { let loc = $1 in
+                  error loc "This #scope is never closed: perhaps #endscope is missing" }
+                /* We include this rule in order to produce a good error message
+                   when a #scope has no matching #endscope. */
 
 | UNDEF
                 { `Undef $1 }

--- a/src/cppo_types.ml
+++ b/src/cppo_types.ml
@@ -85,6 +85,7 @@ type node =
     | `Def of (loc * macro * formals * body)
          (* the list [formals] is empty if and only if no parentheses
             are used at this macro definition site. *)
+    | `Scope of body
     | `Undef of (loc * macro)
     | `Include of (loc * string)
     | `Ext of (loc * string * string)
@@ -146,7 +147,7 @@ let warning loc s =
 
 let dummy_loc = (Lexing.dummy_pos, Lexing.dummy_pos)
 
-let node_loc (node : node) : loc =
+let rec node_loc (node : node) : loc =
   match node with
   | `Ident (loc, _, _)
   | `Def (loc, _, _, _)
@@ -162,6 +163,8 @@ let node_loc (node : node) : loc =
   | `Current_line loc
   | `Current_file loc
       -> loc
+  | `Scope node ->
+      node_loc node
   | `Stringify _
   | `Capitalize _
   | `Concat (_, _)

--- a/src/cppo_types.mli
+++ b/src/cppo_types.mli
@@ -71,6 +71,7 @@ type node =
     | `Def of (loc * macro * formals * body)
          (* the list [formals] is empty if and only if no parentheses
             are used at this macro definition site. *)
+    | `Scope of body
     | `Undef of (loc * macro)
     | `Include of (loc * string)
     | `Ext of (loc * string * string)

--- a/test/def.cppo
+++ b/test/def.cppo
@@ -44,34 +44,45 @@ let forty_two = APPLY(ID, C )
 )
 #enddef
 
+(* In the examples that follow, #scope ... #endscope is used to
+   avoid the need to #undefine local macros such as BODY and F. *)
+
 (* Iteration over an array, with a normal loop. *)
 let iter f a =
+  #scope
   #define BODY(i) (f a.(i))
   LOOP(0, Array.length a, BODY)
-  #undef BODY
+  #endscope
 
 (* Iteration over an array, with an unrolled loop. *)
 let unrolled_iter f a =
+  #scope
   #define BODY(i) (f a.(i))
   UNROLLED_LOOP(0, Array.length a, BODY)
-  #undef BODY
+  #endscope
 
 (* Printing an array, with a normal loop. *)
 let print_int_array a =
+  #scope
   #define F(i) Printf.printf "%d" a.(i)
   LOOP(0, Array.length a, F)
+  #endscope
 
 (* A higher-order macro that produces a definition of [iter],
    and accepts an arbitrary definition of the macro [LOOP]. *)
-#define BODY(i) (f a.(i))
 #def DEFINE_ITER(iter, LOOP : [..[.]])
+  #scope
+  #define BODY(i) (f a.(i))
   let iter f a =
-  LOOP(0, Array.length a, BODY)
+    LOOP(0, Array.length a, BODY)
+  #endscope
 #enddef
-#undef BODY
 
 (* Some noise, which does not affect the above definitions. *)
 #define BODY(i) "noise"
 
 DEFINE_ITER(iter, LOOP)
 DEFINE_ITER(unrolled_iter, UNROLLED_LOOP)
+
+(* Just because we can, undefine BODY. *)
+#undef BODY

--- a/test/def.ref
+++ b/test/def.ref
@@ -28,10 +28,14 @@ let forty_two =
 (* A [for]-loop macro that performs unrolling. *)
 
 # 47 "def.cppo"
+(* In the examples that follow, #scope ... #endscope is used to
+   avoid the need to #undefine local macros such as BODY and F. *)
+
 (* Iteration over an array, with a normal loop. *)
 let iter f a =
+
   
-# 50 "def.cppo"
+# 54 "def.cppo"
   
 (
   for __index = 0 to  Array.length a-1 do
@@ -40,11 +44,12 @@ let iter f a =
 )
  
 
-# 53 "def.cppo"
+# 57 "def.cppo"
 (* Iteration over an array, with an unrolled loop. *)
 let unrolled_iter f a =
+
   
-# 56 "def.cppo"
+# 61 "def.cppo"
    (
   (* #define can be nested inside #def. *)
   (* #def can be nested inside #def. *)
@@ -75,11 +80,12 @@ let unrolled_iter f a =
 )
  
 
-# 59 "def.cppo"
+# 64 "def.cppo"
 (* Printing an array, with a normal loop. *)
 let print_int_array a =
+
   
-# 62 "def.cppo"
+# 68 "def.cppo"
   
 (
   for __index = 0 to  Array.length a-1 do
@@ -88,17 +94,18 @@ let print_int_array a =
 )
  
 
-# 64 "def.cppo"
+# 71 "def.cppo"
 (* A higher-order macro that produces a definition of [iter],
    and accepts an arbitrary definition of the macro [LOOP]. *)
 
-# 73 "def.cppo"
+# 81 "def.cppo"
 (* Some noise, which does not affect the above definitions. *)
 
-# 76 "def.cppo"
+# 84 "def.cppo"
+
 
   let iter f a =
-  
+    
 (
   for __index = 0 to  Array.length a-1 do
      (f a.(__index)) 
@@ -106,10 +113,11 @@ let print_int_array a =
 )
  
  
-# 77 "def.cppo"
+# 85 "def.cppo"
+
 
   let unrolled_iter f a =
-   (
+     (
   (* #define can be nested inside #def. *)
   (* #def can be nested inside #def. *)
   let __finish = ( Array.length a) in
@@ -139,3 +147,6 @@ let print_int_array a =
 )
  
  
+
+# 87 "def.cppo"
+(* Just because we can, undefine BODY. *)

--- a/test/dune
+++ b/test/dune
@@ -92,6 +92,11 @@
  (action (with-stdout-to %{targets} (run %{bin:cppo} %{<}))))
 
 (rule
+ (targets scope.out)
+ (deps (:< scope.cppo))
+ (action (with-stdout-to %{targets} (run %{bin:cppo} %{<}))))
+
+(rule
  (targets higher_order_macros.out)
  (deps (:< higher_order_macros.cppo))
  (action (with-stdout-to %{targets} (run %{bin:cppo} %{<}))))
@@ -135,6 +140,9 @@
 
 (rule (alias runtest) (package cppo)
       (action (diff lexical.ref lexical.out)))
+
+(rule (alias runtest) (package cppo)
+      (action (diff scope.ref scope.out)))
 
 (rule (alias runtest) (package cppo)
       (action (diff higher_order_macros.ref higher_order_macros.out)))
@@ -273,3 +281,12 @@
 
 (rule (alias runtest) (package cppo)
       (action (diff missing_enddef.ref missing_enddef.err)))
+
+(rule
+ (targets missing_endscope.err)
+ (deps (:< missing_endscope.cppo))
+ (action (with-stderr-to %{targets}
+   (with-accepted-exit-codes (not 0) (run %{bin:cppo} %{<})))))
+
+(rule (alias runtest) (package cppo)
+      (action (diff missing_endscope.ref missing_endscope.err)))

--- a/test/higher_order_macros.cppo
+++ b/test/higher_order_macros.cppo
@@ -32,17 +32,22 @@ let forty_two = APPLY(ID, C )
   done\
 )
 
+(* In some of the examples that follow, #scope ... #endscope is used
+   to avoid the need to #undefine local macros such as BODY and F. *)
+
 (* Iteration over an array, with a normal loop. *)
 let iter f a =
+  #scope
   #define BODY(i) (f a.(i))
   LOOP(0, Array.length a, BODY)
-  #undef BODY
+  #endscope
 
 (* Iteration over an array, with an unrolled loop. *)
 let unrolled_iter f a =
+  #scope
   #define BODY(i) (f a.(i))
   UNROLLED_LOOP(0, Array.length a, BODY)
-  #undef BODY
+  #endscope
 
 (* Printing an array, with a normal loop. *)
 let print_int_array a =

--- a/test/higher_order_macros.ref
+++ b/test/higher_order_macros.ref
@@ -22,21 +22,26 @@ let forty_two =
 (* A [for]-loop macro that performs unrolling. *)
 
 # 35 "higher_order_macros.cppo"
+(* In some of the examples that follow, #scope ... #endscope is used
+   to avoid the need to #undefine local macros such as BODY and F. *)
+
 (* Iteration over an array, with a normal loop. *)
 let iter f a =
+
   
-# 38 "higher_order_macros.cppo"
+# 42 "higher_order_macros.cppo"
    (
   for __index = 0 to  Array.length a-1 do
      (f a.(__index)) 
   done
 ) 
 
-# 41 "higher_order_macros.cppo"
+# 45 "higher_order_macros.cppo"
 (* Iteration over an array, with an unrolled loop. *)
 let unrolled_iter f a =
+
   
-# 44 "higher_order_macros.cppo"
+# 49 "higher_order_macros.cppo"
    (
   let __finish = ( Array.length a) in
   let __index = ref (0) in
@@ -51,25 +56,25 @@ let unrolled_iter f a =
   done
 ) 
 
-# 47 "higher_order_macros.cppo"
+# 52 "higher_order_macros.cppo"
 (* Printing an array, with a normal loop. *)
 let print_int_array a =
   
-# 50 "higher_order_macros.cppo"
+# 55 "higher_order_macros.cppo"
    (
   for __index = 0 to  Array.length a-1 do
      Printf.printf "%d" a.(__index) 
   done
 ) 
 
-# 52 "higher_order_macros.cppo"
+# 57 "higher_order_macros.cppo"
 (* A higher-order macro that produces a definition of [iter],
    and accepts an arbitrary definition of the macro [LOOP]. *)
 
-# 60 "higher_order_macros.cppo"
+# 65 "higher_order_macros.cppo"
 (* Some noise, which does not affect the above definitions. *)
 
-# 63 "higher_order_macros.cppo"
+# 68 "higher_order_macros.cppo"
  
   let iter f a = 
    (
@@ -77,7 +82,7 @@ let print_int_array a =
      (f a.(__index)) 
   done
 )  
-# 64 "higher_order_macros.cppo"
+# 69 "higher_order_macros.cppo"
  
   let unrolled_iter f a = 
    (

--- a/test/missing_endscope.cppo
+++ b/test/missing_endscope.cppo
@@ -1,0 +1,14 @@
+(* A common problem: *)
+
+#scope
+#def TWICE(e)
+  e + e
+#enddef
+(* missing #endscope here *)
+
+let f x =
+  TWICE(x)
+
+(* The error is detected by the parser at the end of the file,
+   but we are able to report the location of the #scope as the
+   source of the problem. *)

--- a/test/missing_endscope.ref
+++ b/test/missing_endscope.ref
@@ -1,0 +1,2 @@
+Error: File "missing_endscope.cppo", line 3, characters 0-6
+Error: This #scope is never closed: perhaps #endscope is missing

--- a/test/scope.cppo
+++ b/test/scope.cppo
@@ -1,0 +1,56 @@
+(* This example shows that the definition of FOO that is nested inside
+   the (multi-line) definition of BAR affects only the body of the
+   definition of BAR. It does not affect the text that follows a call
+   to BAR. So, a multi-line macro definition acts as a scope delimiter. *)
+
+#def BAR
+  #define FOO "definition of FOO inside BAR"
+  FOO (* expands to "definition of FOO inside BAR" *)
+#enddef
+#define FOO "definition of FOO at the top level"
+FOO (* expands to "definition of FOO at the top level" *)
+BAR
+FOO (* expands to "definition of FOO at the top level" *)
+
+(* If one wishes to delimit a scope, without actually defining a macro,
+   one can use #scope ... #endscope. *)
+
+#scope
+  #define HELLO "first definition of HELLO"
+  HELLO (* expands to "first definition of HELLO" *)
+#endscope
+#scope
+  #define HELLO "second definition of HELLO"
+  HELLO (* expands to "second definition of HELLO" *)
+#endscope
+HELLO (* this does not expand *)
+
+(* The effect of #scope ... #endscope can be simulated by writing
+   #def DUMMY ... #enddef DUMMY #undef DUMMY
+   but this is a bit unnatural. *)
+
+#def DUMMY
+  #define HELLO "definition of HELLO inside the scope"
+  HELLO (* expands to "definition of HELLO inside the scope" *)
+#enddef
+DUMMY
+#undef DUMMY
+HELLO (* this does not expand *)
+
+(* Another simple example. *)
+
+#scope
+#define HI "I am defined"
+let x = HI (* expands to "I am defined" *)
+#endscope
+#define HI 42
+let y = HI (* expands to 42 *)
+
+(* Check that the effect of #undef is also local.
+   This example relies on the above definition of HI. *)
+
+#scope
+#undef HI
+let qwd = HI (* HI is not recognized as a macro and expands to itself *)
+#endscope
+let z = HI (* expands to 42 *)

--- a/test/scope.cppo
+++ b/test/scope.cppo
@@ -54,3 +54,32 @@ let y = HI (* expands to 42 *)
 let qwd = HI (* HI is not recognized as a macro and expands to itself *)
 #endscope
 let z = HI (* expands to 42 *)
+
+(* Scopes can be nested. *)
+
+#define LEVEL 0
+let x = LEVEL (* expands to 0 *)
+#scope
+  #undef LEVEL
+  #define LEVEL 1
+  let y = LEVEL (* expands to 1 *)
+  #scope
+    #undef LEVEL
+    #define LEVEL 2
+    let z = LEVEL (* expands to 2 *)
+  #endscope
+  let _ = LEVEL (* expands to 1 *)
+#endscope
+let _ = LEVEL (* expands to 0 *)
+
+(* Another example of nesting. *)
+
+#scope
+  #define HELLO "Hello, "
+  #scope
+    #define MAN "man"
+    let message1 = HELLO ^ MAN
+  #endscope
+  (* Here, MAN is no longer defined, but HELLO still is. *)
+  let message2 = HELLO ^ "world"
+#endscope

--- a/test/scope.ref
+++ b/test/scope.ref
@@ -1,0 +1,74 @@
+# 1 "scope.cppo"
+(* This example shows that the definition of FOO that is nested inside
+   the (multi-line) definition of BAR affects only the body of the
+   definition of BAR. It does not affect the text that follows a call
+   to BAR. So, a multi-line macro definition acts as a scope delimiter. *)
+
+# 11 "scope.cppo"
+ "definition of FOO at the top level"  
+# 11 "scope.cppo"
+    (* expands to "definition of FOO at the top level" *)
+# 12 "scope.cppo"
+
+   "definition of FOO inside BAR"  (* expands to "definition of FOO inside BAR" *)
+ 
+# 13 "scope.cppo"
+ "definition of FOO at the top level"  
+# 13 "scope.cppo"
+    (* expands to "definition of FOO at the top level" *)
+
+(* If one wishes to delimit a scope, without actually defining a macro,
+   one can use #scope ... #endscope. *)
+
+
+  
+# 20 "scope.cppo"
+   "first definition of HELLO"  
+# 20 "scope.cppo"
+        (* expands to "first definition of HELLO" *)
+
+  
+# 24 "scope.cppo"
+   "second definition of HELLO"  
+# 24 "scope.cppo"
+        (* expands to "second definition of HELLO" *)
+HELLO (* this does not expand *)
+
+(* The effect of #scope ... #endscope can be simulated by writing
+   #def DUMMY ... #enddef DUMMY #undef DUMMY
+   but this is a bit unnatural. *)
+
+# 36 "scope.cppo"
+
+   "definition of HELLO inside the scope"  (* expands to "definition of HELLO inside the scope" *)
+ 
+# 38 "scope.cppo"
+HELLO (* this does not expand *)
+
+(* Another simple example. *)
+
+
+# 44 "scope.cppo"
+let x = 
+# 44 "scope.cppo"
+         "I am defined"  
+# 44 "scope.cppo"
+           (* expands to "I am defined" *)
+# 47 "scope.cppo"
+let y = 
+# 47 "scope.cppo"
+         42  
+# 47 "scope.cppo"
+           (* expands to 42 *)
+
+(* Check that the effect of #undef is also local.
+   This example relies on the above definition of HI. *)
+
+
+# 54 "scope.cppo"
+let qwd = HI (* HI is not recognized as a macro and expands to itself *)
+let z = 
+# 56 "scope.cppo"
+         42  
+# 56 "scope.cppo"
+           (* expands to 42 *)

--- a/test/scope.ref
+++ b/test/scope.ref
@@ -72,3 +72,60 @@ let z =
          42  
 # 56 "scope.cppo"
            (* expands to 42 *)
+
+(* Scopes can be nested. *)
+
+# 61 "scope.cppo"
+let x = 
+# 61 "scope.cppo"
+         0  
+# 61 "scope.cppo"
+              (* expands to 0 *)
+
+  
+# 65 "scope.cppo"
+  let y = 
+# 65 "scope.cppo"
+           1  
+# 65 "scope.cppo"
+                (* expands to 1 *)
+
+    
+# 69 "scope.cppo"
+    let z = 
+# 69 "scope.cppo"
+             2  
+# 69 "scope.cppo"
+                  (* expands to 2 *)
+  let _ = 
+# 71 "scope.cppo"
+           1  
+# 71 "scope.cppo"
+                (* expands to 1 *)
+let _ = 
+# 73 "scope.cppo"
+         0  
+# 73 "scope.cppo"
+              (* expands to 0 *)
+
+(* Another example of nesting. *)
+
+
+
+    
+# 81 "scope.cppo"
+    let message1 = 
+# 81 "scope.cppo"
+                    "Hello, "  
+# 81 "scope.cppo"
+                         ^ 
+# 81 "scope.cppo"
+                            "man" 
+  
+# 83 "scope.cppo"
+  (* Here, MAN is no longer defined, but HELLO still is. *)
+  let message2 = 
+# 84 "scope.cppo"
+                  "Hello, "  
+# 84 "scope.cppo"
+                       ^ "world"


### PR DESCRIPTION
This PR adds support for `#scope ... #endscope`. This construct limits the effect of macro definitions and undefinitions. In other words, `#endscope` restores the macro environment that existed when `#scope` was entered. It is analogous to `\bgroup` and `\egroup` in LaTeX.

I find this feature to be strongly desirable, as it often removes the need to use `#undef`, which is very inelegant and painful.

This feature can be used to obtain a form of `#include`-with-parameters, as in this example:
```ocaml
#scope
#define FOO 42
#include "bar.ml"
#endscope
```
I find this very useful in practice, and I hope to use it in the next version of [baby](https://github.com/fpottier/baby).

The changes to the source code are minimal; beyond lexer and parser support, the main change is one more case in the function `expand_node`, as follows:

```ocaml
    | `Scope body ->
        (* A [body] is just a [node]. We expand this node, and drop
           the resulting environment; instead, we return the current
           environment. *)
        let env = expand_node ~top g env0 body in
        ignore env;
        env0
```

I have added a new test (`test/scope.{cppo,ref}`) and updated `README.md` and `Changes.md`.
