### PR TITLE
Add -b output binary option

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,7 @@
 ## v1.7.1 (2024-??-??)
 - [bug] Fix `cppo -version`, which used to print a blank line (#92).
+- [+ui] Added the `-b` output binary option so that Windows does
+        not add CRLF endings.
 
 ## v1.7.0 (2024-08-22)
 - [+ui] Multi-line macros, without line terminators `\`,

--- a/src/cppo_main.ml
+++ b/src/cppo_main.ml
@@ -78,6 +78,7 @@ let main () =
   let preserve_quotations = ref false in
   let show_exact_locations = ref false in
   let show_no_locations = ref false in
+  let output_binary = ref false in
   let options = [
     "-D", Arg.String (fun s -> header := ("#define " ^ s ^ "\n") :: !header),
     "DEF
@@ -132,6 +133,10 @@ let main () =
     "
           Do not output any line directive other than those found in the
           input (overrides -s).";
+
+    "-b", Arg.Set output_binary,
+    "
+          Write output without CRLF normalization on Windows.";
 
     "-version", Arg.Unit (fun () ->
                             print_endline Cppo_version.cppo_version;
@@ -215,7 +220,10 @@ Options:" Sys.argv.(0) in
         print_string (Buffer.contents buf);
         flush stdout
     | Some file ->
-        let oc = open_out file in
+        let oc =
+          if !output_binary then open_out_bin file
+          else open_out file
+        in
         output_string oc (Buffer.contents buf);
         close_out oc
 


### PR DESCRIPTION
### Problem

Because cppo writes with `open_out`, CRLF are added to output files on Windows even when the input files are LF.

### Context

- `.cmi` CRC checksums are computed on the marshalled signatures of `.mli` files. These CRC checksums are the source of the `The files xxx.cmi and yyy.cmi makes inconsistent assumptions on interface Zzz` ocamlc/ocamlopt errors.
- The marshalled signatures include the byte locations inside the `.mli` files (because the marshalled `Types.signature` indirectly references `Lexer.position`). Easy to see in a toplevel on any `.cmi` file:
   ```
   utop> require "compiler-libs" ;;
   utop> Cmi_format.read_cmi filename ;;
    (Types.Sig_modtype (<abstr>,
      {Types.mtd_type =
        Some
          (Types.Mty_signature
            [Types.Sig_value (<abstr>,
              {Types.val_type = <abstr>; val_kind = Types.Val_reg;
              val_loc =
                {Location.loc_start = {Lexing.pos_fname = "endianString.cppo.mli"; pos_lnum = 21; pos_bol = 1326; pos_cnum = 1328}; 
                loc_end = {Lexing.pos_fname = "endianString.cppo.mli"; pos_lnum = 21; pos_bol = 1326; pos_cnum = 1364}; 
                loc_ghost = false};
              val_attributes = []; val_uid = Types.Uid.Item {Types.Uid.comp_unit = "EndianString"; id = 0}},
              Types.Exported);
   ```
- CRLF inserted in `.mli` will therefore have different CRC checksums than original LF-ending `.mli` files

The net effect is that I can't share `.cmi`/`.cma` between Unix and Windows machines if CPPO is used as a preprocessor. `The files xxx.cmi and yyy.cmi makes inconsistent assumptions on interface Zzz` is the result.

### Solution

Use `open_out_bin`. This PR hides it behind a command line option, but I actually think binary mode should always have been used.